### PR TITLE
Fix/perp neg

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ All other predictions can be implemented in terms of these nodes. However, it ma
 
 **Perp-Neg Prediction** - Implements https://arxiv.org/abs/2304.04968. This is also implemented less flexibly in vanilla ComfyUI under <ins>_for_testing > Perp-Neg</ins>.<br>
 ``pos_ind = positive - empty; neg_ind = negative - empty``<br>
-``(pos_ind - (pos_ind proj neg_ind) * neg_scale) * cfg_scale + empty``
+``(pos_ind - (neg_ind oproj pos_ind) * neg_scale) * cfg_scale + empty``
 
 # Limitations
 ControlNet is not supported at this time.

--- a/nodes/nodes_pred.py
+++ b/nodes/nodes_pred.py
@@ -562,7 +562,7 @@ class PerpNegPredictor(CachingNoisePredictor):
 
         positive = cond - empty
         negative = uncond - empty
-        perp_neg = proj(positive, negative) * self.neg_scale
+        perp_neg = oproj(negative, positive) * self.neg_scale
         return empty + (positive - perp_neg) * self.cfg_scale
 
 NODE_CLASS_MAPPINGS = {


### PR DESCRIPTION
Adjust Perp-Neg implementation to match Algorithm 1 of the [paper](https://arxiv.org/abs/2304.04968).
With the fix, Perp-Neg correctly ignores components of the negative prompt that are parallel to the positive prompt. In other words, it ignores parts of the negative that are shared with the positive prompt as intended.

Positive: "forest"
Negative: "forest"

Before fix:
![ComfyUI_00199_](https://github.com/redhottensors/ComfyUI-Prediction/assets/114889020/98abacc3-7b33-4e67-9300-89988385dcc9)

After fix:
![ComfyUI_00198_](https://github.com/redhottensors/ComfyUI-Prediction/assets/114889020/4c53b619-5c58-44db-ac03-fa46bd788580)