### PR TITLE
RescaleCFG for SGP node

### DIFF
--- a/nodes/nodes_pred.py
+++ b/nodes/nodes_pred.py
@@ -359,46 +359,26 @@ class ScaledGuidancePredictor(NoisePredictor):
     def get_preds(self):
         return {self} | self.lhs.get_preds() | self.rhs.get_preds()
 
-    def predict_noise(self, x, timestep, model, conds, model_options, seed):
-        lhs = self.lhs.predict_noise(x, timestep, model, conds, model_options, seed)
-        rhs = self.rhs.predict_noise(x, timestep, model, conds, model_options, seed)
+    def predict_noise(self, x, sigma, model, conds, model_options, seed):
+        lhs = self.lhs.predict_noise(x, sigma, model, conds, model_options, seed)
+        rhs = self.rhs.predict_noise(x, sigma, model, conds, model_options, seed)
 
-        def rescale_cfg(args):
-            cond = args["cond"]
-            uncond = args["uncond"]
-            cond_scale = args["cond_scale"]
-            sigma = args["sigma"]
-            sigma = sigma.view(sigma.shape[:1] + (1,) * (cond.ndim - 1))
-            x_orig = args["input"]
+        sigma = sigma.view(sigma.shape[:1] + (1,) * (lhs.ndim - 1))
 
-            # rescale cfg has to be done on v-pred model output
-            x = x_orig / (sigma * sigma + 1.0)
-            cond = ((x - (x_orig - cond)) * (sigma**2 + 1.0) ** 0.5) / (sigma)
-            uncond = ((x - (x_orig - uncond)) * (sigma**2 + 1.0) ** 0.5) / (sigma)
+        # rescale cfg has to be done on v-pred model output
+        x_mod = x / (sigma * sigma + 1.0)
+        cond = ((x_mod - lhs - rhs) * (sigma**2 + 1.0) ** 0.5) / (sigma)
+        uncond = ((x_mod - rhs) * (sigma**2 + 1.0) ** 0.5) / (sigma)
 
-            # rescalecfg
-            x_cfg = uncond + cond_scale * (cond - uncond)
-            ro_pos = torch.std(cond, dim=(1, 2, 3), keepdim=True)
-            ro_cfg = torch.std(x_cfg, dim=(1, 2, 3), keepdim=True)
+        # rescalecfg
+        x_cfg = uncond + self.scale * (cond - uncond)
+        ro_pos = torch.std(cond, dim=(1, 2, 3), keepdim=True)
+        ro_cfg = torch.std(x_cfg, dim=(1, 2, 3), keepdim=True)
 
-            x_rescaled = x_cfg * (ro_pos / ro_cfg)
-            x_final = self.rescale * x_rescaled + (1.0 - self.rescale) * x_cfg
+        x_rescaled = x_cfg * (ro_pos / ro_cfg)
+        x_final = self.rescale * x_rescaled + (1.0 - self.rescale) * x_cfg
 
-            return x_orig - (x - x_final * sigma / (sigma * sigma + 1.0) ** 0.5)
-
-        args = {
-            "cond": x - (lhs + rhs),
-            "uncond": x - rhs,
-            "cond_scale": self.scale,
-            "timestep": timestep,
-            "input": x,
-            "sigma": timestep,
-            "cond_denoised": (lhs + rhs),
-            "uncond_denoised": rhs,
-            "model": model,
-            "model_options": model_options,
-        }
-        return x - rescale_cfg(args)
+        return x_mod - x_final * sigma / (sigma * sigma + 1.0) ** 0.5
 
     def reset_cache(self):
         # reset_cache is fast and idempotent so this is fine

--- a/nodes/nodes_pred.py
+++ b/nodes/nodes_pred.py
@@ -335,20 +335,20 @@ class ScaledGuidancePredictor(NoisePredictor):
                 "min": 0.0,
                 "max": 100.0,
             }),
-            "rescale": ("FLOAT", {
-                "default": 0.0,
-                "step": 0.1,
-                "min": 0.0,
-                "max": 100.0,
+            "rescale_multiplier": ("FLOAT", {
+                "default": 0.0, 
+                "min": 0.0, 
+                "max": 1.0, 
+                "step": 0.01
             }),
         }
     }
 
-    def __init__(self, guidance, baseline, guidance_scale, rescale):
+    def __init__(self, guidance, baseline, guidance_scale, rescale_multiplier):
         self.lhs = guidance
         self.rhs = baseline
         self.scale = guidance_scale
-        self.rescale = rescale
+        self.rescale_multiplier = rescale_multiplier
 
     def get_conds(self):
         return self.merge_conds(self.lhs.get_conds(), self.rhs.get_conds())
@@ -363,13 +363,16 @@ class ScaledGuidancePredictor(NoisePredictor):
         lhs = self.lhs.predict_noise(x, sigma, model, conds, model_options, seed)
         rhs = self.rhs.predict_noise(x, sigma, model, conds, model_options, seed)
 
+        if self.rescale_multiplier <= 0.0:
+            return lhs * self.scale + rhs
+
         sigma = sigma.view(sigma.shape[:1] + (1,) * (lhs.ndim - 1))
         x_scaled = x * (1. / (sigma.square() + 1.0))
         x_cfg = x_scaled - rhs - self.scale * lhs
         ro_pos = torch.std(x_scaled - (lhs + rhs), dim=(1, 2, 3), keepdim=True)
         ro_cfg = torch.std(x_cfg, dim=(1, 2, 3), keepdim=True)
         x_rescaled = x_cfg * (ro_pos / ro_cfg)
-        x_final = torch.lerp(x_cfg, x_rescaled, self.rescale)
+        x_final = torch.lerp(x_cfg, x_rescaled, self.rescale_multiplier)
 
         return x_scaled - x_final
 


### PR DESCRIPTION
Adds a `rescale_multiplier` parameter to the `Scaled Guidance Prediction` node, values above 0 enable the rescale CFG algorithm.

Not being very confident in the simplifications of the calculation, I kept the intermediate steps in the commit history. You might want to squash these.
The port assumes `guidance/lhs = cond - uncond` and `baseline/rhs = uncond` => `cond = lhs + rhs`. I don't know if this holds in contexts more complicated than `guidance = positive - empty`.

References: 
 * [ComfyUI `rescale_cfg`](https://github.com/comfyanonymous/ComfyUI/blob/master/comfy_extras/nodes_model_advanced.py#L185-L206) and [the call site of `sampler_cfg_function`](https://github.com/comfyanonymous/ComfyUI/blob/master/comfy/samplers.py#L251-L254)
 * ["Common Diffusion Noise Schedules and Sample Steps are Flawed"](https://arxiv.org/pdf/2305.08891.pdf), introducing "Rescale Classifier-Free Guidance" in section 3.4
 * v-pred, covered in section 3.2 of the previous paper,  introduced by ["Progressive Distillation for Fast Sampling of Diffusion Models"](https://arxiv.org/pdf/2202.00512.pdf).