### PR TITLE
Add call to post_cfg_function patch for cfg++ compatability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.py[cod]


### PR DESCRIPTION
Adds optional parameters to the sampler to allow for CFG++ compatibility (which fetches uncond via post_cfg_function in the cfg++ sampler).

This interface isn't super intuitive, but I don't see an obvious way to make it better until the core patches that allow documenting parameters in a way that shows up in the UI is possible.